### PR TITLE
Bump @joystream/types version and fix build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "status": "node lib/status"
   },
   "dependencies": {
-    "@joystream/types": "^0.6.0",
+    "@joystream/types": "^0.9.1",
     "@polkadot/api": "^0.96.1",
     "@polkadot/keyring": "^1.7.0-beta.5",
     "@polkadot/types": "^0.96.1",
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@polkadot/ts": "^0.1.56",
-    "typescript": "^3.7.2"
+    "typescript": "3.7.2"
   }
 }

--- a/src/get-code.ts
+++ b/src/get-code.ts
@@ -1,5 +1,5 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import {registerJoystreamTypes} from '@joystream/types'
+import {registerJoystreamTypes} from '@joystream/types';
 
 async function main () {
   const provider = new WsProvider('ws://127.0.0.1:9944');

--- a/src/role_params.ts
+++ b/src/role_params.ts
@@ -1,6 +1,8 @@
+import { registerJoystreamTypes } from '@joystream/types';
 import { RoleParameters } from '@joystream/types/lib/roles';
 
-//
+registerJoystreamTypes(); // Just to avoid circular reference while loading modules
+
 let params = new RoleParameters(
     {"min_stake":3000,"min_actors":5,"max_actors":10,"reward":10,"reward_period":600,"bonding_period":600,"unbonding_period":600,"min_service_period":600,"startup_grace_period":600,"entry_request_fee":50}
 );


### PR DESCRIPTION
Changes included in this PR:
- Bump `@joystream/types` to the new version (`^0.9.1`)
- Force TypeScript version `3.7.2` to avoid build error mentioned in https://github.com/Joystream/joystream-api-examples/issues/2
- Add `registerJoystreamTypes` in `src/role_params.ts` to avoid circular-reference error when importing just a single type from `@joystream/types` (quickfix before implementing one in `@joystream/types`)